### PR TITLE
Correct DATEDIFF translation to PostgreSQL

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -40,7 +40,7 @@ From,To,Pattern,Replacement
 "sql server","postgresql","DATEADD(dd,@days,@date)","(@date + @days)"
 "sql server","postgresql","DATEADD(mm,@months,@date)","CAST((@date + @months*INTERVAL'1 month') AS DATE)"
 "sql server","postgresql","DATEADD(yy,@years,@date)","CAST((@date + @years*INTERVAL'1 year') AS DATE)"
-"sql server","postgresql","DATEDIFF(dd,@start, @end)","(@end - @start)"
+"sql server","postgresql","DATEDIFF(dd,@start, @end)","CAST(EXTRACT(EPOCH FROM (@end - @start))/86400 AS INTEGER)"
 "sql server","postgresql","GETDATE()","CURRENT_DATE"
 "sql server","postgresql","+ '@a'","|| '@a'"
 "sql server","postgresql","'@a' +","'@a' ||"


### PR DESCRIPTION
Update the postgres translation of datediff to output an integer number
of days instead of a postgres interval data type.

Fixes #1

Signed-off-by: Aaron Browne aaron0browne@gmail.com
