### PR TITLE
Remove 'Prevent Divide by zero error' translation rule (issue #75).

### DIFF
--- a/SqlRender.Rproj
+++ b/SqlRender.Rproj
@@ -13,6 +13,6 @@ RnwWeave: knitr
 LaTeX: pdfLaTeX
 
 BuildType: Package
-PackageInstallArgs: --with-keep.source --no-multiarch
+PackageInstallArgs: --with-keep.source
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace

--- a/SqlRender.Rproj
+++ b/SqlRender.Rproj
@@ -13,6 +13,6 @@ RnwWeave: knitr
 LaTeX: pdfLaTeX
 
 BuildType: Package
-PackageInstallArgs: --with-keep.source
+PackageInstallArgs: --with-keep.source --no-multiarch
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace

--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -155,7 +155,6 @@ postgresql,SELECT @a INTO @b;,CREATE TABLE @b AS\nSELECT\n@a;
 postgresql,#,
 postgresql,SELECT TOP @([0-9]+)rows @a;,SELECT @a LIMIT @rows;
 postgresql,"WITH @cte AS (SELECT @s1 '@literal' @s2)","WITH @cte AS (SELECT @s1 CAST('@literal' as TEXT) @s2)"
-redshift,"WHERE @where (@a / @b)","WHERE @where (@a / NULLIF(@b, 0))"
 redshift,"ROUND(@a,@b)","ROUND(CAST(@a AS FLOAT),@b)"
 redshift,"ROUND(@expression,@length,@trunc)","case when @trunc = 0 then ROUND(@expression,@length) else TRUNC(@expression,@length) end"
 redshift,"CONVERT(DATE, @a)","TO_DATE(@a, 'yyyymmdd')"

--- a/tests/testthat/test-translateSql.R
+++ b/tests/testthat/test-translateSql.R
@@ -1719,14 +1719,6 @@ test_that("Postgres String literal within CTE should be explicitly casted to cha
     "WITH  expression  AS (SELECT CAST('my literal' as TEXT), col1, CAST('other literal' as TEXT), col2 FROM table WHERE a = b) SELECT * FROM expression ORDER BY 1, 2, 3, 4;")
 })
 
-test_that("RedShift Prevent 'Divide by zero' error", {
-  sql <- translateSql(
-    "select m.range_high, m.value_as_number FROM cdm.MEASUREMENT WHERE range_high > 0.0000 AND (value_as_number / range_high) > 1.0000;",
-    sourceDialect = "sql server", targetDialect = "redshift")$sql
-  expect_equal_ignore_spaces(sql, 
-    "select m.range_high, m.value_as_number FROM cdm.MEASUREMENT WHERE range_high > 0.0000 AND (value_as_number / NULLIF(range_high, 0)) > 1.0000;")
-})
-
 test_that("RedShift XOR operator", {
   sql <- translateSql("select a ^ b from c where a = 1;", sourceDialect = "sql server", targetDialect = "redshift")$sql
   expect_equal_ignore_spaces(sql, "select a # b from c where a = 1;")


### PR DESCRIPTION
This rule affects GROUP BY clause which may lead to 'column must appear in the GROUP BY clause or be used in an aggregate function' error.

The rule was intended to prevent division by zero when generating cohorts. Instead of handling this with SqlRender, I created [corresponding pull request](https://github.com/OHDSI/WebAPI/pull/208).