### PR TITLE
Fix 'column does not exist' error when using CONVERT function in Redshift

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -157,7 +157,6 @@ postgresql,SELECT TOP @([0-9]+)rows @a;,SELECT @a LIMIT @rows;
 postgresql,"WITH @cte AS (SELECT @s1 '@literal' @s2)","WITH @cte AS (SELECT @s1 CAST('@literal' as TEXT) @s2)"
 redshift,"ROUND(@a,@b)","ROUND(CAST(@a AS FLOAT),@b)"
 redshift,"ROUND(@expression,@length,@trunc)","case when @trunc = 0 then ROUND(@expression,@length) else TRUNC(@expression,@length) end"
-redshift,"CONVERT(DATE, @a)","TO_DATE(@a, 'yyyymmdd')"
 redshift,"DATEADD(dd,@days,@date)","DATEADD(day,@days,@date)"
 redshift,"DATEADD(m,@months,@date)","DATEADD(month,@months,@date)"
 redshift,"DATEADD(mm,@months,@date)","DATEADD(month,@months,@date)"
@@ -320,6 +319,8 @@ redshift,"ISNUMERIC(@s)","REGEXP_INSTR(@s, '^[\-\+]?(\\d*\\.)?\\d+([Ee][\-\+]?\\
 redshift,"PATINDEX(@pattern,@expression)","REGEXP_INSTR(@expression, case when LEFT(@pattern,1)<>'%' and RIGHT(@pattern,1)='%' then '^' else '' end||TRIM('%' FROM REPLACE(@pattern,'_','.'))||case when LEFT(@pattern,1)='%' and RIGHT(@pattern,1)<>'%' then '$' else '' end)"
 redshift,"WITH @cte AS (SELECT @s1 '@literal' @s2)","WITH @cte AS (SELECT @s1 CAST('@literal' as TEXT) @s2)"
 redshift,^,#
+redshift,"CONVERT(DATE, @a)","CAST(@a as DATE)"
+redshift,"CONVERT(TIMESTAMPTZ, @a)","CONVERT(TIMESTAMP WITH TIME ZONE, @a)"
 pdw,VARCHAR(MAX),VARCHAR(1000)
 pdw,HINT DISTRIBUTE_ON_KEY(@key) @hint WITH @a AS @b SELECT @c INTO @d FROM @e;,HINT DISTRIBUTE_ON_KEY(@key) @hint\nCREATE TABLE @d WITH (DISTRIBUTION = HASH(@key))\nAS\nWITH @a AS @b SELECT\n@c\nFROM\n@e;
 pdw,"WITH @a AS @b SELECT @c1 subject_id, @c2 INTO @d FROM @e;","CREATE TABLE @d WITH (DISTRIBUTION = HASH(subject_id))\nAS\nWITH @a AS @b SELECT\n@c1 subject_id, @c2\nFROM\n@e;"

--- a/tests/testthat/test-translateSql.R
+++ b/tests/testthat/test-translateSql.R
@@ -1823,3 +1823,14 @@ test_that("translateSQL sql server -> pdw hint DISTKEY + SORTKEY on CTAS", {
  expect_equal_ignore_spaces(sql, "--HINT DISTRIBUTE_ON_KEY(row_id) SORT_ON_KEY(start_date)\n\nIF XACT_STATE() = 1 COMMIT; CREATE TABLE #my_table WITH (LOCATION = USER_DB, DISTRIBUTION = HASH(row_id)) AS\nSELECT\n * \nFROM\n other_table;")
 })
 
+test_that("translateSQL sql server -> redshift CONVERT to DATE", {
+ sql <- translateSql("select CONVERT(DATE, start_date) from my_table;",
+ targetDialect = "redshift")$sql
+ expect_equal_ignore_spaces(sql, "select CAST(start_date as DATE) from my_table;")
+})
+
+test_that("translateSQL sql server -> redshift CONVERT to TIMESTAMPTZ", {
+ sql <- translateSql("select CONVERT(TIMESTAMPTZ, start_date) from my_table;",
+ targetDialect = "redshift")$sql
+ expect_equal_ignore_spaces(sql, "select CONVERT(TIMESTAMP WITH TIME ZONE, start_date) from my_table;")
+})


### PR DESCRIPTION
Redshift supports CONVERT function, but it generates error when passing
certain types into it.
The following statement causes error 'Invalid operation: column "date" does not exist'

	select CONVERT(date, '01/01/2017');

And this query causes error 'Invalid operation: column "timestamptz" does not exist'

	select CONVERT(TIMESTAMPTZ, '01/01/2017');