### PR TITLE
Fix netezza rule for RIGHT()

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -507,7 +507,7 @@ netezza,SELECT @a INTO #@b FROM @c;,CREATE TEMP TABLE @b\nAS\nSELECT\n@a\nFROM\n
 netezza,SELECT @a INTO @b FROM @c;,CREATE TABLE @b AS\nSELECT\n@a\nFROM\n@c;
 netezza,#,
 netezza,"LEFT(@variable,@b)","SUBSTR(@variable, 1, @b)"
-netezza,"RIGHT(@variable,@b)","SUBSTR(@variable, LENGTH(@variable)-@b, @b)"
+netezza,"RIGHT(@variable,@b)","SUBSTR(@variable, LENGTH(@variable)-@b+1, @b)"
 netezza,SELECT TOP @([0-9]+)rows @a;,SELECT @a LIMIT @rows;
 netezza,(SELECT TOP @([0-9]+)rows @a),(SELECT @a LIMIT @rows)
 netezza,"CONCAT(@a, @b, @c)","CONCAT(@a, CONCAT(@b, @c))"

--- a/tests/testthat/test-translateSql.R
+++ b/tests/testthat/test-translateSql.R
@@ -552,7 +552,7 @@ test_that("translateSQL sql server -> Netezza LEFT functions", {
 test_that("translateSQL sql server -> Netezza RIGHT functions", {
   sql <- translateSql("SELECT RIGHT(x,4);",
                       targetDialect = "netezza")$sql
-  expect_equal_ignore_spaces(sql, "SELECT SUBSTR(x, LENGTH(x) - 4, 4);")
+  expect_equal_ignore_spaces(sql, "SELECT SUBSTR(x, LENGTH(x) - 4 + 1, 4);")
 })
 
 test_that("translateSQL sql server -> Netezza DELETE FROM WHERE", {


### PR DESCRIPTION
This is a post-fix to #113 that broke the RIGHT() function.

