### PR TITLE
How to address BigQuery safe_cast methos

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -573,6 +573,8 @@ netezza,DATETIME2,TIMESTAMP
 netezza,"ISNUMERIC(@a)","CASE WHEN translate(@a,'0123456789','') in ('','.','-','-.') THEN 1 ELSE 0 END"
 netezza,"HASHBYTES('MD5',@a)","hash(@a)"
 netezza,"CONVERT(VARBINARY, @a, 1)","hex_to_binary(@a)"
+bigquery,"ISNUMERIC(@a)=1 AND CAST(@a AS INT)","SAFE_CAST(@a as int64)"
+bigquery,"ISNUMERIC(@a)=1 AND CAST(@a AS FLOAT)","SAFE_CAST(@a as float64)"
 bigquery,"CONVERT(VARBINARY, @a, 1)","safe_cast(concat('0x', @a) as int64)"
 bigquery,SELECT TOP @([0-9]+)rows @a;,SELECT @a LIMIT @rows;
 bigquery,(SELECT TOP @([0-9]+)rows @a),(SELECT @a LIMIT @rows)


### PR DESCRIPTION
BigQuery tends to execute expressions in WHERE clause with a very high parallelism level which makes behavior dramatically different compared to regular databases. There is a high probability of the bugs in case of CASTS with many 'AND' expressions. It is known and well documented feature of the Bigquery and it offers a bunch of SAFE_* methods to address this feature. As we cannot write code directly for the BigQuery I want to offer a new approach how can we utilize SAFE_* methods and address only BigQuery storage by collapsing queries like: "isNumeric(a)=1 and cast(a to int)" to safe_cast.
