### PR TITLE
Fix #287: Remove # in temp table names on Redshift

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -383,6 +383,7 @@ redshift,^,#
 redshift,"CONVERT(DATE, @a)","CAST(@a as DATE)"
 redshift,"CONVERT(TIMESTAMPTZ, @a)","CONVERT(TIMESTAMP WITH TIME ZONE, @a)"
 redshift,UPDATE STATISTICS @a;,ANALYZE @a;
+redshift,#,
 pdw,CREATE INDEX @index_name ON #@table (@variable);,-- PDW does not support non-clustered index on temp tables.
 pdw,VARCHAR(MAX),VARCHAR(1000)
 pdw,HINT DISTRIBUTE_ON_KEY(@key) @hint WITH @a AS @b SELECT @c INTO @d FROM @e;,HINT DISTRIBUTE_ON_KEY(@key) @hint\nCREATE TABLE @d WITH (DISTRIBUTION = HASH(@key))\nAS\nWITH @a AS @b SELECT\n@c\nFROM\n@e;

--- a/tests/testthat/test-translateSql.R
+++ b/tests/testthat/test-translateSql.R
@@ -2372,6 +2372,14 @@ test_that("translate sql server -> Redshift window function NTILE no sort specif
   )
 })
 
+test_that("translate sql server -> Redshift temp table names", {
+  sql <- translate("select * from #temp", targetDialect = "redshift")
+  expect_equal_ignore_spaces(sql, "select * from temp")  
+  
+  sql <- translate("select * from ##temp", targetDialect = "redshift")
+  expect_equal_ignore_spaces(sql, "select * from temp")
+})
+
 test_that("translate sql server -> Netezza concat with more than two arguments", {
   sql <- translate("SELECT CONCAT(a,b,c,d,e) FROM x;", targetDialect = "netezza")
   expect_equal_ignore_spaces(sql, "SELECT a || b || c || d || e FROM x;")


### PR DESCRIPTION
Fix #287 

