### PR TITLE
Fixes reordering of columns during insert for spark

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -981,8 +981,8 @@ spark,tempdb..#@table +,%temp_prefix%%session_id% ||
 spark,#,%temp_prefix%%session_id%
 spark,"--HINT BUCKET(@a, @b)",
 spark,"--HINT PARTITION(@a @b)",
-spark,"INSERT INTO @table (@columns) SELECT @values;","WITH insertion_temp AS (\n(SELECT @values) UNION ALL (SELECT @columns FROM @table))\nINSERT OVERWRITE TABLE @table SELECT * FROM insertion_temp;"
-spark,"INSERT INTO @table (@columns) VALUES @values;","WITH insertion_temp AS (\n(SELECT * FROM VALUES @values T(@columns)) UNION ALL (SELECT @columns FROM @table))\nINSERT OVERWRITE TABLE @table SELECT * FROM insertion_temp;"
+spark,"INSERT INTO @table (@columns) SELECT @values;","WITH insertion_temp AS (\n(SELECT @values) UNION ALL (SELECT @columns FROM @table))\nINSERT OVERWRITE TABLE @table (@columns) SELECT * FROM insertion_temp;"
+spark,"INSERT INTO @table (@columns) VALUES @values;","WITH insertion_temp AS (\n(SELECT * FROM VALUES @values T(@columns)) UNION ALL (SELECT @columns FROM @table))\nINSERT OVERWRITE TABLE @table (@columns) SELECT * FROM insertion_temp;"
 spark,"HINT DISTRIBUTE_ON_KEY(@key) CREATE TABLE IF NOT EXISTS @table\nUSING DELTA\nAS\n@definition;","HINT DISTRIBUTE_ON_KEY(@key)\nCREATE TABLE IF NOT EXISTS @table\nUSING DELTA\nAS\n@definition;\nOPTIMIZE @table ZORDER BY @key;"
 spark,"HINT DISTRIBUTE_ON_KEY(@key) IF OBJECT_ID('@d', 'U') IS NULL WITH @a AS @b SELECT @c INTO @d FROM @e;",HINT DISTRIBUTE_ON_KEY(@key)\nCREATE TABLE IF NOT EXISTS @d\nUSING DELTA\nAS\nWITH @a AS @b SELECT\n@c\nFROM\n@e;\nOPTIMIZE @d ZORDER BY @key;
 spark,"HINT DISTRIBUTE_ON_KEY(@key) IF OBJECT_ID('@b', 'U') IS NULL SELECT @a INTO @b FROM @c;",HINT DISTRIBUTE_ON_KEY(@key) \nCREATE TABLE IF NOT EXISTS @b\nUSING DELTA\nAS\nSELECT\n@a\nFROM\n@c;\nOPTIMIZE @b ZORDER BY @key;

--- a/tests/testthat/test-translate-spark.R
+++ b/tests/testthat/test-translate-spark.R
@@ -382,7 +382,7 @@ test_that("translate sql server -> spark INSERT INTO SELECT", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "WITH insertion_temp AS (\n(SELECT c FROM cte1) UNION ALL (SELECT b int FROM a ))\nINSERT OVERWRITE TABLE a  SELECT * FROM insertion_temp;"
+    "WITH insertion_temp AS (\n(SELECT c FROM cte1) UNION ALL (SELECT b int FROM a ))\nINSERT OVERWRITE TABLE a (b) SELECT * FROM insertion_temp;"
   )
 })
 
@@ -392,7 +392,7 @@ test_that("translate sql server -> spark INSERT INTO VALUES", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "WITH insertion_temp AS (\n(SELECT * FROM VALUES (1,0),(2,0),(3,1) T(key,value)) UNION ALL (SELECT key,value FROM my_table ))\nINSERT OVERWRITE TABLE my_table  SELECT * FROM insertion_temp;"
+    "WITH insertion_temp AS (\n(SELECT * FROM VALUES (1,0),(2,0),(3,1) T(key,value)) UNION ALL (SELECT key,value FROM my_table ))\nINSERT OVERWRITE TABLE my_table (key,value) SELECT * FROM insertion_temp;"
   )
 })
 

--- a/tests/testthat/test-translate-spark.R
+++ b/tests/testthat/test-translate-spark.R
@@ -382,7 +382,7 @@ test_that("translate sql server -> spark INSERT INTO SELECT", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "WITH insertion_temp AS (\n(SELECT c FROM cte1) UNION ALL (SELECT b int FROM a ))\nINSERT OVERWRITE TABLE a (b) SELECT * FROM insertion_temp;"
+    "WITH insertion_temp AS (\n(SELECT c FROM cte1) UNION ALL (SELECT b int FROM a ))\nINSERT OVERWRITE TABLE a (b int) SELECT * FROM insertion_temp;"
   )
 })
 


### PR DESCRIPTION
We're getting wrong results when order in the temp table is not the same as in the spark table