### PR TITLE
CAST(@a AS DATE) handling for Snowflake - fixes #372

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -1287,6 +1287,10 @@ snowflake,"HASHBYTES('MD5',@a)","MD5(@a)"
 snowflake,"CONVERT(VARBINARY, @a, 1)","CAST(CONCAT('x', @a) AS BIT(32))"
 snowflake,"CONVERT(DATE, @a)","TO_DATE(@a, 'yyyymmdd')"
 snowflake,"CONVERT(VARCHAR,@date,112)","TO_CHAR(@date, 'YYYYMMDD')"
+snowflake,"CAST('@a' AS DATE)","TO_DATE('@a', 'YYYYMMDD')"
+snowflake,"CAST('@a' + @b AS DATE)","TO_DATE('@a' + @b, 'YYYYMMDD')"
+snowflake,"CAST(@a + '@b' AS DATE)","TO_DATE(@a + '@b', 'YYYYMMDD')"
+snowflake,"CAST(CONCAT(@a) AS DATE)","TO_DATE(CONCAT(@a), 'YYYYMMDD')"
 snowflake,GETDATE(),CURRENT_DATE
 snowflake,+ '@a',|| '@a'
 snowflake,'@a' +,'@a' ||

--- a/tests/testthat/test-translate-snowflake.R
+++ b/tests/testthat/test-translate-snowflake.R
@@ -210,5 +210,9 @@ test_that("translate sql server -> snowflake bitwise and", {
   expect_equal_ignore_spaces(sql, "SELECT BITAND((a+b) , c/123) FROM table ;")
 })
 
+test_that("translate sql server -> Snowflake CAST(AS DATE)", {
+  sql <- translate("CAST('20000101' AS DATE);", targetDialect = "snowflake")
+  expect_equal_ignore_spaces(sql, "TO_DATE('20000101', 'YYYYMMDD');")
+})
 
 # rJava::J('org.ohdsi.sql.SqlTranslate')$setReplacementPatterns('inst/csv/replacementPatterns.csv')


### PR DESCRIPTION
Aims to fix #372 for Snowflake. I added translation rules as you described in https://github.com/OHDSI/SqlRender/pull/371#issuecomment-2268611180 but I'm unsure if I've covered all translations with the tests I contributed for Snowflake (based on what I saw for Oracle).