### PR TITLE
fix and simplify support for CTEs in DDL statements for InterSystems

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -1386,10 +1386,6 @@ iris,+ CAST(@a AS varchar),|| CAST(@a AS varchar)
 iris,COUNT_BIG(@a),COUNT(@a)
 iris,.dbo.,.
 iris,CREATE TABLE #@table (@definition),DROP TABLE IF EXISTS #@table; CREATE GLOBAL TEMPORARY TABLE #@table (@definition)
-iris,"WITH @a AS (@b), @c CREATE TABLE @d AS @e;","DROP TABLE IF EXISTS #@a;\n CREATE GLOBAL TEMPORARY TABLE #@a AS @b;\n WITH @c CREATE TABLE @d AS @e;\n DROP TABLE IF EXISTS #@a;"
-iris,WITH @a AS (@b) CREATE TABLE @c AS SELECT @d;,DROP TABLE IF EXISTS #@a;\n CREATE GLOBAL TEMPORARY TABLE #@a AS @b;\n CREATE TABLE @c AS SELECT @d;\n DROP TABLE IF EXISTS #@a;
-iris,"WITH @a AS (@b), @c CREATE GLOBAL TEMPORARY TABLE @d AS @e;","DROP TABLE IF EXISTS #@a;\n CREATE GLOBAL TEMPORARY TABLE #@a AS @b;\n WITH @c CREATE GLOBAL TEMPORARY TABLE @d AS @e;\n DROP TABLE IF EXISTS #@a;"
-iris,WITH @a AS (@b) CREATE GLOBAL TEMPORARY TABLE @c AS @d;,DROP TABLE IF EXISTS #@a;\n CREATE GLOBAL TEMPORARY TABLE #@a AS @b;\n CREATE GLOBAL TEMPORARY TABLE @c AS @d;\n DROP TABLE IF EXISTS #@a;
 iris,"IF OBJECT_ID('@table', 'U') IS NULL CREATE TABLE @table (@definition);",CREATE TABLE IF NOT EXISTS @table (@definition);
 iris,"IF OBJECT_ID('@table', 'U') IS NOT NULL DROP TABLE @table;",DROP TABLE IF EXISTS @table;
 iris,"IF OBJECT_ID('tempdb..#@table', 'U') IS NOT NULL DROP TABLE #@table;",DROP TABLE IF EXISTS #@table;
@@ -1404,6 +1400,9 @@ iris,SELECT @a INTO #@b FROM @c;,CREATE GLOBAL TEMPORARY TABLE #@b AS SELECT @a 
 iris,SELECT @a INTO @b FROM @c;,CREATE TABLE @b AS SELECT @a FROM @c;
 iris,SELECT @a INTO @b;,CREATE TABLE @b AS SELECT @a;
 iris,SELECT @a INTO #@b;,CREATE GLOBAL TEMPORARY TABLE #@b AS SELECT @a;
+iris,"WITH @cte CREATE TABLE #@table AS @select;","CREATE GLOBAL TEMPORARY TABLE #@table AS WITH @cte @select;"
+iris,"WITH @cte CREATE GLOBAL TEMPORARY TABLE @table AS @select;","CREATE GLOBAL TEMPORARY TABLE @table AS WITH @cte @select;"
+iris,"WITH @cte CREATE TABLE @table AS @select;","CREATE TABLE @table AS WITH @cte @select;"
 iris,#,%temp_prefix%%session_id%
 iris,UPDATE STATISTICS @a;,TUNE TABLE @a;
 iris,"--HINT BUCKET(@a, @b)", "-- haven't looked into this yet, skip it for now"

--- a/tests/testthat/test-translate-iris.R
+++ b/tests/testthat/test-translate-iris.R
@@ -111,3 +111,19 @@ test_that("translate sql server -> InterSystems IRIS FROM ( VALUES ... ) clause"
   sql <- translate("SELECT * FROM (SELECT TRY_CAST(a AS INT) AS a, TRY_CAST(b AS DOUBLE) AS b FROM (VALUES (1, 2), (2, 3)) AS drvd(a, b);", targetDialect = "iris")
   expect_equal_ignore_spaces(sql, "SELECT * FROM (SELECT CAST(a AS INT) AS a, CAST(b AS DOUBLE) AS b FROM ((SELECT NULL AS a, NULL AS b WHERE (0 = 1)) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 2, 3)) AS values_table;")
 })
+
+
+# test CTE with DDL
+test_that("translate sql server -> InterSystems IRIS DDL with CTE", {
+  sql <- translate("WITH a AS (SELECT 123 as test), b AS (SELECT test FROM t_test) CREATE TABLE t AS SELECT * FROM a UNION b;", targetDialect = "iris")
+  expect_equal_ignore_spaces(sql, "CREATE TABLE t AS WITH a AS (SELECT 123 as test), b AS (SELECT test FROM t_test) SELECT * FROM a UNION b;")
+})
+test_that("translate sql server -> InterSystems IRIS DDL with CTE", {
+  sql <- translate("WITH a AS (SELECT 123 as test), b AS (SELECT test FROM t_test) CREATE TABLE #t AS SELECT * FROM a UNION b;", targetDialect = "iris")
+  expect_equal_ignore_spaces(sql, paste0("CREATE GLOBAL TEMPORARY TABLE ", getTempTablePrefix(), "t AS WITH a AS (SELECT 123 as test), b AS (SELECT test FROM t_test) SELECT * FROM a UNION b;"))
+})
+test_that("translate sql server -> InterSystems IRIS DDL with CTE", {
+  sql <- translate("WITH a AS (SELECT 123 as test) SELECT * INTO #t FROM a;", targetDialect = "iris")
+  expect_equal_ignore_spaces(sql, paste0("CREATE GLOBAL TEMPORARY TABLE ", getTempTablePrefix(), "t AS WITH a AS (SELECT 123 as test) SELECT * FROM a;"))
+})
+


### PR DESCRIPTION
This change simplifies the rewrite rules for DDL statements (including implicit through `SELECT .. INTO ..`) that include CTEs. Previously, these were rewritten into separate statements to create temp tables, but ended up with malformed statements for some complex `SELECT .. INTO ..` statements produced by Achilles.
We now found how we can stick to the existing CTEs by proper placement in the CTAS structure.

The change includes a few unit tests on sample queries in this case.