### PR TITLE
Spark admin queries

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -1126,7 +1126,7 @@ spark,COUNT_BIG(@a),COUNT(@a)
 spark,SQUARE(@a),((@a)*(@a))
 spark,NEWID(),UUID()
 spark,.dbo.,.
-spark,CREATE CLUSTERED INDEX @index_name ON @table (@variable);,ALTER TABLE @table CLUSTER BY (@variable);
+spark,CREATE CLUSTERED INDEX @index_name ON @table (@variable);,
 spark,CREATE UNIQUE CLUSTERED INDEX @index_name ON @table (@variable);,ALTER TABLE @table ADD CONSTRAINT @index_name UNIQUE(@variable);
 spark,PRIMARY KEY NONCLUSTERED,PRIMARY KEY
 spark,DATETIME,TIMESTAMP

--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -1126,9 +1126,9 @@ spark,COUNT_BIG(@a),COUNT(@a)
 spark,SQUARE(@a),((@a)*(@a))
 spark,NEWID(),UUID()
 spark,.dbo.,.
-spark,CREATE CLUSTERED INDEX @index_name ON @table (@variable);,
-spark,CREATE UNIQUE CLUSTERED INDEX @index_name ON @table (@variable);,
-spark,PRIMARY KEY NONCLUSTERED,
+spark,CREATE CLUSTERED INDEX @index_name ON @table (@variable);,ALTER TABLE @table CLUSTER BY (@variable);
+spark,CREATE UNIQUE CLUSTERED INDEX @index_name ON @table (@variable);,ALTER TABLE @table ADD CONSTRAINT @index_name UNIQUE(@variable);
+spark,PRIMARY KEY NONCLUSTERED,PRIMARY KEY
 spark,DATETIME,TIMESTAMP
 spark,DATETIME2,TIMESTAMP
 spark,VARCHAR(MAX),STRING
@@ -1140,7 +1140,7 @@ spark,(SELECT TOP @([0-9]+)rows @a),(SELECT @a LIMIT @rows)
 spark,SELECT DISTINCT TOP @([0-9]+)rows @a;,SELECT DISTINCT @a LIMIT @rows;
 spark,(SELECT DISTINCT TOP @([0-9]+)rows @a),(SELECT DISTINCT @a LIMIT @rows)
 spark,"WITH @cte AS (SELECT @s1 '@literal' @s2)","WITH @cte AS (SELECT @s1 CAST('@literal' as STRING) @s2)"
-spark,UPDATE STATISTICS @a;,
+spark,UPDATE STATISTICS @a;,ANALYZE TABLES @a COMPUTE STATISTICS;
 spark,"SELECT @columns FROM (@a) @x,(@b) @y;","SELECT @columns FROM (@a) @x cross join (@b) @y;"
 spark,"ALTER TABLE @table ADD COLUMN @([\w_-]+)column @type DEFAULT @default;","ALTER TABLE @table ADD COLUMN @column @type; \nALTER TABLE @table SET TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'supported'); \nALTER TABLE @table ALTER COLUMN @column SET DEFAULT @default;"
 spark,"CAST(@a AS DATE)","IF(try_cast(@a AS DATE) IS NULL, to_date(cast(@a AS STRING), 'yyyyMMdd'), try_cast(@a AS DATE))"

--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -1140,7 +1140,7 @@ spark,(SELECT TOP @([0-9]+)rows @a),(SELECT @a LIMIT @rows)
 spark,SELECT DISTINCT TOP @([0-9]+)rows @a;,SELECT DISTINCT @a LIMIT @rows;
 spark,(SELECT DISTINCT TOP @([0-9]+)rows @a),(SELECT DISTINCT @a LIMIT @rows)
 spark,"WITH @cte AS (SELECT @s1 '@literal' @s2)","WITH @cte AS (SELECT @s1 CAST('@literal' as STRING) @s2)"
-spark,UPDATE STATISTICS @a;,ANALYZE TABLES @a COMPUTE STATISTICS;
+spark,UPDATE STATISTICS @a;,ANALYZE TABLE @a COMPUTE STATISTICS;
 spark,"SELECT @columns FROM (@a) @x,(@b) @y;","SELECT @columns FROM (@a) @x cross join (@b) @y;"
 spark,"ALTER TABLE @table ADD COLUMN @([\w_-]+)column @type DEFAULT @default;","ALTER TABLE @table ADD COLUMN @column @type; \nALTER TABLE @table SET TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'supported'); \nALTER TABLE @table ALTER COLUMN @column SET DEFAULT @default;"
 spark,"CAST(@a AS DATE)","IF(try_cast(@a AS DATE) IS NULL, to_date(cast(@a AS STRING), 'yyyyMMdd'), try_cast(@a AS DATE))"

--- a/tests/testthat/test-translate-spark.R
+++ b/tests/testthat/test-translate-spark.R
@@ -302,7 +302,7 @@ test_that("translate sql server -> spark table admin", {
   sql <- translate("CREATE CLUSTERED INDEX index_name ON some_table (variable);",
     targetDialect = "spark"
   )
-  expect_equal_ignore_spaces(sql, "ALTER TABLE some_table CLUSTER BY (variable);")
+  expect_equal_ignore_spaces(sql, "")
 
   sql <- translate("CREATE UNIQUE CLUSTERED INDEX index_name ON some_table (variable);",
     targetDialect = "spark"

--- a/tests/testthat/test-translate-spark.R
+++ b/tests/testthat/test-translate-spark.R
@@ -317,7 +317,7 @@ test_that("translate sql server -> spark table admin", {
   sql <- translate("UPDATE STATISTICS test;",
     targetDialect = "spark"
   )
-  expect_equal_ignore_spaces(sql, "ANALYZE TABLES test COMPUTE STATISTICS;")
+  expect_equal_ignore_spaces(sql, "ANALYZE TABLE test COMPUTE STATISTICS;")
 })
 
 test_that("translate sql server -> spark datetime", {
@@ -495,5 +495,5 @@ test_that("translate sql server -> spark ALTER TABLE ADD CONSTRAINT", {
 
 test_that("translate sql server -> spark analyze table", {
   sql <- translate("UPDATE STATISTICS results_schema.heracles_results;", targetDialect = "spark")
-  expect_equal_ignore_spaces(sql, "ANALYZE results_schema.heracles_results COMPUTE STATISTICS;")
+  expect_equal_ignore_spaces(sql, "ANALYZE TABLE results_schema.heracles_results COMPUTE STATISTICS;")
 })

--- a/tests/testthat/test-translate-spark.R
+++ b/tests/testthat/test-translate-spark.R
@@ -302,22 +302,22 @@ test_that("translate sql server -> spark table admin", {
   sql <- translate("CREATE CLUSTERED INDEX index_name ON some_table (variable);",
     targetDialect = "spark"
   )
-  expect_equal_ignore_spaces(sql, "")
+  expect_equal_ignore_spaces(sql, "ALTER TABLE some_table CLUSTER BY (variable);")
 
   sql <- translate("CREATE UNIQUE CLUSTERED INDEX index_name ON some_table (variable);",
     targetDialect = "spark"
   )
-  expect_equal_ignore_spaces(sql, "")
+  expect_equal_ignore_spaces(sql, "ALTER TABLE some_table ADD CONSTRAINT index_name UNIQUE(variable);")
 
   sql <- translate("PRIMARY KEY NONCLUSTERED",
     targetDialect = "spark"
   )
-  expect_equal_ignore_spaces(sql, "")
+  expect_equal_ignore_spaces(sql, "PRIMARY KEY")
 
   sql <- translate("UPDATE STATISTICS test;",
     targetDialect = "spark"
   )
-  expect_equal_ignore_spaces(sql, "")
+  expect_equal_ignore_spaces(sql, "ANALYZE TABLES test COMPUTE STATISTICS;")
 })
 
 test_that("translate sql server -> spark datetime", {
@@ -488,3 +488,12 @@ test_that("translate sql server -> spark create table with FLOAT", {
   expect_equal_ignore_spaces(sql, "CREATE TABLE a.b  \nUSING DELTA\n AS\nSELECT\nCAST(NULL AS DOUBLE) AS x  WHERE 1 = 0;")
 })
 
+test_that("translate sql server -> spark ALTER TABLE ADD CONSTRAINT", {
+  sql <- translate("ALTER TABLE cdm.MEASUREMENT ADD CONSTRAINT xpk_MEASUREMENT PRIMARY KEY NONCLUSTERED (measurement_id);", targetDialect = "spark")
+  expect_equal_ignore_spaces(sql, "ALTER TABLE cdm.MEASUREMENT ADD CONSTRAINT xpk_MEASUREMENT PRIMARY KEY (measurement_id);")
+})
+
+test_that("translate sql server -> spark analyze table", {
+  sql <- translate("UPDATE STATISTICS results_schema.heracles_results;", targetDialect = "spark")
+  expect_equal_ignore_spaces(sql, "ANALYZE results_schema.heracles_results COMPUTE STATISTICS;")
+})


### PR DESCRIPTION
Fixes #392.
Also addresses one other admin query; `update statistics` translate into [`ANALYZE TABLE COMPUTE STATISTICS;`](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-aux-analyze-compute-statistics)

Note that I also found a way to translate the last missing admin query, an index to Spark, [by creating a cluster](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-cluster-by). But did not include it here as it might need additional discussion.
