### PR TITLE
Fix DATEADD with second/minute/hour dropping the datetime argument on Oracle and SQLite

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ Bugfixes:
 
 1. Now correctly translating `CREATE UNIQUE CLUSTERED INDEX`, `PRIMARY KEY NONCLUSTERED`, and `UPDATE STATISTICS` on Spark.
 
+2. Now correctly translating `DATEADD()` with `second`, `minute`, or `hour` on Oracle and SQLite (the datetime argument was being dropped, leaving an unresolved `@date` token in the output).
+
 
 SqlRender 1.19.5
 ================

--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -20,9 +20,9 @@ oracle,<par_open>,(
 oracle,<par_close>,)
 oracle,EXCEPT,MINUS
 oracle,"CONCAT(@a, @b, @c)","CONCAT(@a, CONCAT(@b, @c))"
-oracle,"DATEADD(second,@seconds,@datetime)","(@date + NUMTODSINTERVAL(@seconds, 'second'))"
-oracle,"DATEADD(minute,@minutes,@datetime)","(@date + NUMTODSINTERVAL(@minutes, 'minute'))"
-oracle,"DATEADD(hour,@hours,@datetime)","(@date + NUMTODSINTERVAL(@hours, 'hour'))"
+oracle,"DATEADD(second,@seconds,@datetime)","(@datetime + NUMTODSINTERVAL(@seconds, 'second'))"
+oracle,"DATEADD(minute,@minutes,@datetime)","(@datetime + NUMTODSINTERVAL(@minutes, 'minute'))"
+oracle,"DATEADD(hour,@hours,@datetime)","(@datetime + NUMTODSINTERVAL(@hours, 'hour'))"
 oracle,"DATEADD(d,@days,@date)","(@date + NUMTODSINTERVAL(@days, 'day'))"
 oracle,"DATEADD(dd,@days,@date)","(@date + NUMTODSINTERVAL(@days, 'day'))"
 oracle,"DATEADD(day,@days,@date)","(@date + NUMTODSINTERVAL(@days, 'day'))"
@@ -833,9 +833,9 @@ sqlite,DATETIME,REAL
 sqlite,DATETIME2,REAL
 sqlite,"CONVERT(DATE, @a)","CAST(STRFTIME('%s', SUBSTR(CAST(@a AS TEXT), 1, 4) || '-' || SUBSTR(CAST(@a AS TEXT), 5, 2) || '-' || SUBSTR(CAST(@a AS TEXT), 7)) AS REAL)"
 sqlite,CAST(@a AS DATE),"CAST(STRFTIME('%s', SUBSTR(CAST(@a AS TEXT), 1, 4) || '-' || SUBSTR(CAST(@a AS TEXT), 5, 2) || '-' || SUBSTR(CAST(@a AS TEXT), 7)) AS REAL)"
-sqlite,"DATEADD(second,@seconds,@datetime)","CAST(STRFTIME('%s', DATETIME(@date, 'unixepoch', (@seconds)||' seconds')) AS REAL)"
-sqlite,"DATEADD(minute,@minutes,@datetime)","CAST(STRFTIME('%s', DATETIME(@date, 'unixepoch', (@minutes)||' minutes')) AS REAL)"
-sqlite,"DATEADD(hour,@hours,@datetime)","CAST(STRFTIME('%s', DATETIME(@date, 'unixepoch', (@hours)||' hours')) AS REAL)"
+sqlite,"DATEADD(second,@seconds,@datetime)","CAST(STRFTIME('%s', DATETIME(@datetime, 'unixepoch', (@seconds)||' seconds')) AS REAL)"
+sqlite,"DATEADD(minute,@minutes,@datetime)","CAST(STRFTIME('%s', DATETIME(@datetime, 'unixepoch', (@minutes)||' minutes')) AS REAL)"
+sqlite,"DATEADD(hour,@hours,@datetime)","CAST(STRFTIME('%s', DATETIME(@datetime, 'unixepoch', (@hours)||' hours')) AS REAL)"
 sqlite,"DATEADD(d,@days,@date)","CAST(STRFTIME('%s', DATETIME(@date, 'unixepoch', (@days)||' days')) AS REAL)"
 sqlite,"DATEADD(dd,@days,@date)","CAST(STRFTIME('%s', DATETIME(@date, 'unixepoch', (@days)||' days')) AS REAL)"
 sqlite,"DATEADD(day,@days,@date)","CAST(STRFTIME('%s', DATETIME(@date, 'unixepoch', (@days)||' days')) AS REAL)"

--- a/tests/testthat/test-translate-oracle.R
+++ b/tests/testthat/test-translate-oracle.R
@@ -75,6 +75,30 @@ test_that("translate sql server -> Oracle DATEADD", {
     sql,
     "SELECT (drug_era_end_date + NUMTODSINTERVAL(30, 'day')) FROM drug_era;"
   )
+
+  sql <- translate("SELECT DATEADD(second,30,drug_era_end_date) FROM drug_era;",
+    targetDialect = "oracle"
+  )
+  expect_equal_ignore_spaces(
+    sql,
+    "SELECT (drug_era_end_date + NUMTODSINTERVAL(30, 'second')) FROM drug_era;"
+  )
+
+  sql <- translate("SELECT DATEADD(minute,30,drug_era_end_date) FROM drug_era;",
+    targetDialect = "oracle"
+  )
+  expect_equal_ignore_spaces(
+    sql,
+    "SELECT (drug_era_end_date + NUMTODSINTERVAL(30, 'minute')) FROM drug_era;"
+  )
+
+  sql <- translate("SELECT DATEADD(hour,30,drug_era_end_date) FROM drug_era;",
+    targetDialect = "oracle"
+  )
+  expect_equal_ignore_spaces(
+    sql,
+    "SELECT (drug_era_end_date + NUMTODSINTERVAL(30, 'hour')) FROM drug_era;"
+  )
 })
 
 test_that("translate sql server -> Oracle functional index", {

--- a/tests/testthat/test-translate-sqlite.R
+++ b/tests/testthat/test-translate-sqlite.R
@@ -34,6 +34,26 @@ test_that("translate sql server -> SQLite add month", {
   )
 })
 
+test_that("translate sql server -> SQLite add second/minute/hour", {
+  sql <- translate("DATEADD(second,30,date)", targetDialect = "sqlite")
+  expect_equal_ignore_spaces(
+    sql,
+    "CAST(STRFTIME('%s', DATETIME(date, 'unixepoch', (30)||' seconds')) AS REAL)"
+  )
+
+  sql <- translate("DATEADD(minute,30,date)", targetDialect = "sqlite")
+  expect_equal_ignore_spaces(
+    sql,
+    "CAST(STRFTIME('%s', DATETIME(date, 'unixepoch', (30)||' minutes')) AS REAL)"
+  )
+
+  sql <- translate("DATEADD(hour,30,date)", targetDialect = "sqlite")
+  expect_equal_ignore_spaces(
+    sql,
+    "CAST(STRFTIME('%s', DATETIME(date, 'unixepoch', (30)||' hours')) AS REAL)"
+  )
+})
+
 test_that("translate sql server -> SQLite WITH SELECT INTO", {
   sql <- translate("WITH cte1 AS (SELECT a FROM b) SELECT c INTO d FROM cte1;",
     targetDialect = "sqlite"


### PR DESCRIPTION
Fixes #396.

The Oracle and SQLite replacement patterns for `DATEADD(second|minute|hour, n, x)` capture the datetime argument as `@datetime` on the pattern side but reference `@date` on the replacement side. `@date` is never bound, so SqlRender emits it verbatim and drops the actual argument:

```
translate("SELECT DATEADD(second,30,drug_era_end_date) FROM drug_era;", targetDialect = "oracle")
# before: SELECT (@date + NUMTODSINTERVAL(30, 'second')) FROM drug_era
# after:  SELECT (drug_era_end_date + NUMTODSINTERVAL(30, 'second')) FROM drug_era
```

The `day` / `month` / `year` rows for both dialects already capture and reference `@date` consistently, and the PostgreSQL / DuckDB `second` / `minute` / `hour` rows already reference `@datetime` on both sides — so only these six rows change (`@date` → `@datetime` on the replacement side).

The existing Oracle and SQLite `DATEADD` tests only covered day/month units, so this path was untested; added `second` / `minute` / `hour` cases to `test-translate-oracle.R` and `test-translate-sqlite.R`.

### QA

Verified by running the compiled `SqlTranslate` engine against the updated `replacementPatterns.csv` for Oracle and SQLite, including nested `DATEADD` and a regression pass over `day` / `month` / `year` / `DATEDIFF` and the PostgreSQL / DuckDB rows (unchanged). The R `testthat` suite was not run locally (no R/rJava environment here) — CI will exercise the added tests.

`inst/java/SqlRender.jar` / `inst/csv/jarChecksum.txt` are intentionally left untouched, matching prior pattern-fix PRs (#390, #393, …); the R package reads `inst/csv/replacementPatterns.csv` directly via `system.file()`.

<sub>AI-assisted: investigation, fix, and tests prepared with Claude Code under my direction and reviewed by me.</sub>
