### PR TITLE
fix sqlite translation of isnumeric

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -878,7 +878,7 @@ sqlite,RAND(),((RANDOM()+9223372036854775808) / 18446744073709551615)
 sqlite,LEN(@a),LENGTH(@a)
 sqlite,"LOG(@expression,@base)","(LOG(@expression)/LOG(@base))"
 sqlite,"ISNULL(@a,@b)","COALESCE(@a,@b)"
-sqlite,"ISNUMERIC(@a)","CASE WHEN CAST(CAST(@a AS numeric) AS char) = RTRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END"
+sqlite,"ISNUMERIC(@a)","CASE WHEN CAST(CAST(@a AS numeric) AS char) = RTRIM(CAST(@a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END"
 sqlite,COUNT_BIG(@a),COUNT(@a)
 sqlite,NEWID(),RANDOM()
 sqlite,"RIGHT(@a,@b)","SUBSTR(CAST(@a AS TEXT),-@b)"
@@ -1160,7 +1160,7 @@ sqlite extended,RAND(),RANDOM()
 sqlite extended,LEN(@a),LENGTH(@a)
 sqlite extended,"LOG(@expression,@base)","(LOG(@expression)/LOG(@base))"
 sqlite extended,"ISNULL(@a,@b)","COALESCE(@a,@b)"
-sqlite extended,"ISNUMERIC(@a)","CASE WHEN CAST(CAST(@a AS numeric) AS char) = RTRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END"
+sqlite extended,"ISNUMERIC(@a)","CASE WHEN CAST(CAST(@a AS numeric) AS char) = RTRIM(CAST(@a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END"
 sqlite extended,COUNT_BIG(@a),COUNT(@a)
 sqlite extended,NEWID(),RANDOM()
 sqlite extended,"RIGHT(@a,@b)","SUBSTR(@a,-@b)"

--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -878,7 +878,7 @@ sqlite,RAND(),((RANDOM()+9223372036854775808) / 18446744073709551615)
 sqlite,LEN(@a),LENGTH(@a)
 sqlite,"LOG(@expression,@base)","(LOG(@expression)/LOG(@base))"
 sqlite,"ISNULL(@a,@b)","COALESCE(@a,@b)"
-sqlite,"ISNUMERIC(@a)","CASE WHEN @a GLOB '[0-9]*' OR @a GLOB '[0-9]*.[0-9]*' OR @a GLOB '.[0-9]*' THEN 1 ELSE 0 END"
+sqlite,"ISNUMERIC(@a)","CASE WHEN CAST(CAST(@a AS numeric) AS char) = RTRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END"
 sqlite,COUNT_BIG(@a),COUNT(@a)
 sqlite,NEWID(),RANDOM()
 sqlite,"RIGHT(@a,@b)","SUBSTR(CAST(@a AS TEXT),-@b)"
@@ -1160,7 +1160,7 @@ sqlite extended,RAND(),RANDOM()
 sqlite extended,LEN(@a),LENGTH(@a)
 sqlite extended,"LOG(@expression,@base)","(LOG(@expression)/LOG(@base))"
 sqlite extended,"ISNULL(@a,@b)","COALESCE(@a,@b)"
-sqlite extended,"ISNUMERIC(@a)","CASE WHEN @a GLOB '[0-9]*' OR @a GLOB '[0-9]*.[0-9]*' OR @a GLOB '.[0-9]*' THEN 1 ELSE 0 END"
+sqlite extended,"ISNUMERIC(@a)","CASE WHEN CAST(CAST(@a AS numeric) AS char) = RTRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END"
 sqlite extended,COUNT_BIG(@a),COUNT(@a)
 sqlite extended,NEWID(),RANDOM()
 sqlite extended,"RIGHT(@a,@b)","SUBSTR(@a,-@b)"

--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -878,7 +878,7 @@ sqlite,RAND(),((RANDOM()+9223372036854775808) / 18446744073709551615)
 sqlite,LEN(@a),LENGTH(@a)
 sqlite,"LOG(@expression,@base)","(LOG(@expression)/LOG(@base))"
 sqlite,"ISNULL(@a,@b)","COALESCE(@a,@b)"
-sqlite,"ISNUMERIC(@a)","CASE WHEN CAST(CAST(@a AS numeric) AS char) = RTRIM(CAST(@a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END"
+sqlite,"ISNUMERIC(@a)","CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END"
 sqlite,COUNT_BIG(@a),COUNT(@a)
 sqlite,NEWID(),RANDOM()
 sqlite,"RIGHT(@a,@b)","SUBSTR(CAST(@a AS TEXT),-@b)"
@@ -1160,7 +1160,7 @@ sqlite extended,RAND(),RANDOM()
 sqlite extended,LEN(@a),LENGTH(@a)
 sqlite extended,"LOG(@expression,@base)","(LOG(@expression)/LOG(@base))"
 sqlite extended,"ISNULL(@a,@b)","COALESCE(@a,@b)"
-sqlite extended,"ISNUMERIC(@a)","CASE WHEN CAST(CAST(@a AS numeric) AS char) = RTRIM(CAST(@a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END"
+sqlite extended,"ISNUMERIC(@a)","CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END"
 sqlite extended,COUNT_BIG(@a),COUNT(@a)
 sqlite extended,NEWID(),RANDOM()
 sqlite extended,"RIGHT(@a,@b)","SUBSTR(@a,-@b)"

--- a/tests/testthat/test-translate-sqlite-extended.R
+++ b/tests/testthat/test-translate-sqlite-extended.R
@@ -99,12 +99,12 @@ test_that("translate sql server -> sqlite ISNUMERIC", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "SELECT CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
+    "SELECT CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
   )
   sql <- translate("SELECT a FROM table WHERE ISNUMERIC(a) = 1", targetDialect = "sqlite extended")
   expect_equal_ignore_spaces(
     sql,
-    "SELECT a FROM table WHERE CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END = 1"
+    "SELECT a FROM table WHERE CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END = 1"
   )
 })
 

--- a/tests/testthat/test-translate-sqlite-extended.R
+++ b/tests/testthat/test-translate-sqlite-extended.R
@@ -99,12 +99,12 @@ test_that("translate sql server -> sqlite ISNUMERIC", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "SELECT CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
+    "SELECT CASE WHEN TRIM(CAST(CAST(a AS numeric) AS char), '0.') = TRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
   )
   sql <- translate("SELECT a FROM table WHERE ISNUMERIC(a) = 1", targetDialect = "sqlite extended")
   expect_equal_ignore_spaces(
     sql,
-    "SELECT a FROM table WHERE CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END = 1"
+    "SELECT a FROM table WHERE CASE WHEN TRIM(CAST(CAST(a AS numeric) AS char), '0.') = TRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1"
   )
 })
 

--- a/tests/testthat/test-translate-sqlite-extended.R
+++ b/tests/testthat/test-translate-sqlite-extended.R
@@ -99,12 +99,12 @@ test_that("translate sql server -> sqlite ISNUMERIC", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "SELECT CASE WHEN CASE WHEN a GLOB '[0-9]*' OR a GLOB '[0-9]*.[0-9]*' OR a GLOB '.[0-9]*' THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
+    "SELECT CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
   )
   sql <- translate("SELECT a FROM table WHERE ISNUMERIC(a) = 1", targetDialect = "sqlite extended")
   expect_equal_ignore_spaces(
     sql,
-    "SELECT a FROM table WHERE CASE WHEN a GLOB '[0-9]*' OR a GLOB '[0-9]*.[0-9]*' OR a GLOB '.[0-9]*' THEN 1 ELSE 0 END = 1"
+    "SELECT a FROM table WHERE CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1"
   )
 })
 

--- a/tests/testthat/test-translate-sqlite-extended.R
+++ b/tests/testthat/test-translate-sqlite-extended.R
@@ -99,12 +99,12 @@ test_that("translate sql server -> sqlite ISNUMERIC", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "SELECT CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
+    "SELECT CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
   )
   sql <- translate("SELECT a FROM table WHERE ISNUMERIC(a) = 1", targetDialect = "sqlite extended")
   expect_equal_ignore_spaces(
     sql,
-    "SELECT a FROM table WHERE CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1"
+    "SELECT a FROM table WHERE CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END = 1"
   )
 })
 

--- a/tests/testthat/test-translate-sqlite.R
+++ b/tests/testthat/test-translate-sqlite.R
@@ -128,12 +128,12 @@ test_that("translate sql server -> sqlite ISNUMERIC", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "SELECT CASE WHEN CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
+    "SELECT CASE WHEN CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
   )
   sql <- translate("SELECT a FROM table WHERE ISNUMERIC(a) = 1", targetDialect = "sqlite")
   expect_equal_ignore_spaces(
     sql,
-    "SELECT a FROM table WHERE CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END = 1"
+    "SELECT a FROM table WHERE CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END = 1"
   )
 })
 

--- a/tests/testthat/test-translate-sqlite.R
+++ b/tests/testthat/test-translate-sqlite.R
@@ -128,12 +128,12 @@ test_that("translate sql server -> sqlite ISNUMERIC", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "SELECT CASE WHEN CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
+    "SELECT CASE WHEN CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
   )
   sql <- translate("SELECT a FROM table WHERE ISNUMERIC(a) = 1", targetDialect = "sqlite")
   expect_equal_ignore_spaces(
     sql,
-    "SELECT a FROM table WHERE CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1"
+    "SELECT a FROM table WHERE CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') OR CAST(@a AS char) = '0' THEN 1 ELSE 0 END = 1"
   )
 })
 

--- a/tests/testthat/test-translate-sqlite.R
+++ b/tests/testthat/test-translate-sqlite.R
@@ -128,12 +128,12 @@ test_that("translate sql server -> sqlite ISNUMERIC", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "SELECT CASE WHEN CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
+    "SELECT CASE WHEN CASE WHEN TRIM(CAST(CAST(a AS numeric) AS char), '0.') = TRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
   )
   sql <- translate("SELECT a FROM table WHERE ISNUMERIC(a) = 1", targetDialect = "sqlite")
   expect_equal_ignore_spaces(
     sql,
-    "SELECT a FROM table WHERE CASE WHEN TRIM(CAST(CAST(@a AS numeric) AS char), '0.') = TRIM(CAST(@a AS char), '0.') THEN 1 ELSE 0 END = 1"
+    "SELECT a FROM table WHERE CASE WHEN TRIM(CAST(CAST(a AS numeric) AS char), '0.') = TRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1"
   )
 })
 

--- a/tests/testthat/test-translate-sqlite.R
+++ b/tests/testthat/test-translate-sqlite.R
@@ -128,12 +128,12 @@ test_that("translate sql server -> sqlite ISNUMERIC", {
   )
   expect_equal_ignore_spaces(
     sql,
-    "SELECT CASE WHEN CASE WHEN a GLOB '[0-9]*' OR a GLOB '[0-9]*.[0-9]*' OR a GLOB '.[0-9]*' THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
+    "SELECT CASE WHEN CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1 THEN a ELSE b FROM c;"
   )
   sql <- translate("SELECT a FROM table WHERE ISNUMERIC(a) = 1", targetDialect = "sqlite")
   expect_equal_ignore_spaces(
     sql,
-    "SELECT a FROM table WHERE CASE WHEN a GLOB '[0-9]*' OR a GLOB '[0-9]*.[0-9]*' OR a GLOB '.[0-9]*' THEN 1 ELSE 0 END = 1"
+    "SELECT a FROM table WHERE CASE WHEN CAST(CAST(a AS numeric) AS char) = RTRIM(CAST(a AS char), '0.') THEN 1 ELSE 0 END = 1"
   )
 })
 


### PR DESCRIPTION
Fixes #400 by a round-trip cast, modified from [this sqlite forum discussion.](https://sqlite.org/forum/info/6952c2332c166396).
`CAST(CAST(@a AS numeric) AS char) = RTRIM(CAST(@a AS char), '0.')`

In sqlite, casting of a non-numeric string to numeric returns a 0. This round-trip cast uses that behaviour to check if value is still te same after casting back to character.

A `TRIM` is needed for leading and trailing zero, e.g. '1.0', '001', '.1', which are removed in the round-trip. This does introduce a few edge-cases, e.g. '.' or '0.0.0' will be considered numeric.

A general note: it is very likely that `ISNUMERIC` will have, after rendering,  different behaviour in different dialects. Has the actual behaviour of SqlRender been tested across dialects? This is important, because [the DQD cdmDataType check](https://ohdsi.github.io/DataQualityDashboard/articles/checks/cdmDatatype.html) uses `ISNUMERIC` to check whether integer columns indeed contain integers.
A few edge-cases discovered while testing: 1e6, 1e-6, 10^6, 10^-6, 000123, 010, 0000, 00.123, '  1', '1   ', '1.'.